### PR TITLE
Add simple wall paint visualizer screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'view/paint_visualizer_screen.dart';
 
 void main() => runApp(MyApp());
 
@@ -203,6 +204,14 @@ class _AnalyticsScreenState extends State<AnalyticsScreen> {
             : errorMessage != null
             ? Center(child: Text(errorMessage!, style: TextStyle(color: Colors.red, fontSize: 16)))
             : buildAnalyticsContent(),
+        floatingActionButton: FloatingActionButton(
+          child: const Icon(Icons.brush),
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const PaintVisualizerScreen()),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/view/paint_visualizer_screen.dart
+++ b/lib/view/paint_visualizer_screen.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+
+class PaintVisualizerScreen extends StatefulWidget {
+  const PaintVisualizerScreen({Key? key}) : super(key: key);
+
+  @override
+  State<PaintVisualizerScreen> createState() => _PaintVisualizerScreenState();
+}
+
+class _PaintVisualizerScreenState extends State<PaintVisualizerScreen> {
+  File? _imageFile;
+  final List<Offset> _points = [];
+  Color _selectedColor = Colors.red.withOpacity(0.5);
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _imageFile = File(picked.path);
+        _points.clear();
+      });
+    }
+  }
+
+  void _onTapDown(TapDownDetails details) {
+    setState(() {
+      _points.add(details.localPosition);
+    });
+  }
+
+  void _clearPoints() => setState(() => _points.clear());
+
+  void _pickColor() async {
+    Color tmp = _selectedColor;
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        content: SingleChildScrollView(
+          child: ColorPicker(
+            pickerColor: tmp,
+            onColorChanged: (c) => tmp = c.withOpacity(0.5),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Select'),
+          )
+        ],
+      ),
+    );
+    setState(() => _selectedColor = tmp);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Paint Visualizer'),
+        actions: [
+          IconButton(onPressed: _pickImage, icon: const Icon(Icons.photo)),
+          IconButton(onPressed: _pickColor, icon: const Icon(Icons.color_lens)),
+          IconButton(onPressed: _clearPoints, icon: const Icon(Icons.clear)),
+        ],
+      ),
+      body: Center(
+        child: _imageFile == null
+            ? const Text('Pick an image to start')
+            : LayoutBuilder(
+                builder: (context, constraints) {
+                  return GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTapDown: _onTapDown,
+                    child: Stack(
+                      children: [
+                        Positioned.fill(
+                          child: Image.file(
+                            _imageFile!,
+                            fit: BoxFit.contain,
+                          ),
+                        ),
+                        Positioned.fill(
+                          child: CustomPaint(
+                            painter: _WallPainter(points: _points, color: _selectedColor),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}
+
+class _WallPainter extends CustomPainter {
+  final List<Offset> points;
+  final Color color;
+
+  _WallPainter({required this.points, required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (points.length < 2) return;
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+    final path = Path()..addPolygon(points, true);
+    canvas.drawPath(path, paint);
+
+    final borderPaint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    canvas.drawPath(path, borderPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _WallPainter oldDelegate) {
+    return oldDelegate.points != points || oldDelegate.color != color;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   fl_chart: 0.63.0
   http: ^1.4.0
+  image_picker: ^1.0.7
+  flutter_colorpicker: ^1.0.3
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add paint visualizer screen with polygon drawing, color picker and image picker
- expose screen with a new button in `AnalyticsScreen`
- include `image_picker` and `flutter_colorpicker` dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882bcaaf850832e9a9fcdfba019738b